### PR TITLE
Adicionada funcionalidade de reboot via software (opção 7 ao switch)

### DIFF
--- a/ATV02MicrocontroladoresGPIO.c
+++ b/ATV02MicrocontroladoresGPIO.c
@@ -1,6 +1,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "pico/stdlib.h"
+#include <pico/bootrom.h>
+
 
 // Definição dos pinos
 #define LED_GREEN 11
@@ -83,6 +85,11 @@ int main()
             printf("Todos os LED's foram desligados.\n");
             break;
         case '6': // Acionar o buzzer
+            break;
+        case '7': //Sair do modo de execução e habilitar o modo de gravação via software (reboot)
+            printf("Modo de gravação via software habilitado.\n");
+            reset_usb_boot(0,0);
+            break;
         default:
             printf("Comando inválido. Tente novamente.\n");
             break;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,9 @@ pico_enable_stdio_usb(ATV02MicrocontroladoresGPIO 1)
 
 # Add the standard library to the build
 target_link_libraries(ATV02MicrocontroladoresGPIO
-        pico_stdlib)
+        pico_stdlib
+        pico_bootrom
+        )
 
 # Add the standard include files to the build
 target_include_directories(ATV02MicrocontroladoresGPIO PRIVATE


### PR DESCRIPTION
### O que foi feito:

- Adicionei a funcionalidade de reinicialização do microcontrolador no modo de gravação via software (reboot) ao comando 7.
- Quando o usuário digita 7 no terminal, o microcontrolador reinicia e entra no modo de gravação via USB, permitindo a atualização do firmware.

### Mudanças realizadas:

1. Implementação do comando 7:

- Adicionei a função reset_usb_boot(0, 0) para reiniciar o microcontrolador no modo de gravação via software.
- O comando 7 agora imprime uma mensagem no terminal indicando que o modo de gravação foi habilitado.

### Dependências:

- Esta funcionalidade depende da biblioteca pico/bootrom.h, que já está incluída no código e no CMakeLists.